### PR TITLE
add t-function to status message

### DIFF
--- a/includes/pages.php
+++ b/includes/pages.php
@@ -287,6 +287,6 @@ function share_light_node_email_form_submit($form, &$form_state) {
     $form_state['redirect'] = $redirect;
   } else {
     $form_state['redirect'] = 'node/' . $node->nid;
-    drupal_set_message('Thank you for sharing. You are awesome!');
+    drupal_set_message(t('Thank you for sharing. You are awesome!'));
   }
 }


### PR DESCRIPTION
Right now, it is not possible to change the text of the status message that the user sees after sending a share-email. drupal_set_message should better be used with a t-function to enable translations.
