### PR TITLE
remove urlencode

### DIFF
--- a/src/Facebook.php
+++ b/src/Facebook.php
@@ -9,7 +9,7 @@ class Facebook extends ChannelBase {
     return array(
       'title' => 'Facebook',
       'href' => 'https://www.facebook.com/sharer.php',
-      'query' => array('u' => urlencode($url)),
+      'query' => array('u' => ($url)),
       'attributes' => array(
         'title' => t('Share this via Facebook!'),
         'data-share' => 'facebook',


### PR DESCRIPTION
Facebook sharer seems to provide encoding too, which leads to double encoded urls that aren't decodable anymore ;-)
e.g. https://moreonion.zendesk.com/agent/tickets/1198 & https://moreonion.zendesk.com/agent/tickets/1199
