### PR TITLE
Remove hardcoded "Message from Sender" content

### DIFF
--- a/share-message-body.tpl.php
+++ b/share-message-body.tpl.php
@@ -17,7 +17,7 @@
         <tr>
           <td style="font-family:Arial,Helvetica,sans-serif; font-size:12px;">
             <?php if ($values['message']): ?>
-            <p><?php print t('Message from Sender'); ?></p><p><?php print $values['message']; ?></p>
+            <p><?php print $values['message']; ?></p>
             <?php endif; ?>
             <?php echo $values['footer']; ?>
           </td>


### PR DESCRIPTION
The message is not necessary and not editable by users. It will always be added before the share email, which is annoying.
Therefore this proposal to remove it!
